### PR TITLE
Markdown support

### DIFF
--- a/lib/ex_styledoc/markdown.ex
+++ b/lib/ex_styledoc/markdown.ex
@@ -1,0 +1,23 @@
+defmodule ExStyledoc.Markdown do
+  @moduledoc """
+  Transform a given document in Markdown to HTML.
+  """
+
+  @doc """
+  Earmark specific options:
+    * `gfm` - boolean. Turns on Github Flavored Markdown extensions. True by default
+    * `breaks` - boolean. Only applicable if `gfm` is enabled. Makes all line
+      breaks significant (so every line in the input is a new line in the output)
+    * `smartypants`: boolean. Turns on smartypants processing, so quotes become curly,
+      two or three hyphens become en and em dashes, and so on. True by default
+  """
+  def to_html(text, opts \\ []) do
+    options = struct(Earmark.Options,
+             gfm: Keyword.get(opts, :gfm, true),
+             line: Keyword.get(opts, :line, 1),
+             file: Keyword.get(opts, :file),
+             breaks: Keyword.get(opts, :breaks, false),
+             smartypants: Keyword.get(opts, :smartypants, true))
+    Earmark.as_html!(text, options)
+  end
+end

--- a/lib/ex_styledoc/parser.ex
+++ b/lib/ex_styledoc/parser.ex
@@ -4,24 +4,16 @@ defmodule ExStyledoc.Parser do
   """
 
   import Phoenix.HTML, only: [safe_to_string: 1]
-  # import Phoenix.HTML.Tag, only: [content_tag: 3]
 
   @doc """
   Parse a styledoc.
   """
   def parse_styledoc(doc) do
-    Regex.replace(~r/```(.*?)```/s, doc, &parse_example/2)
+    Regex.replace(~r/```example(.*?)```/s, doc, &parse_example/2)
     |> ExStyledoc.Markdown.to_html()
   end
 
   defp parse_example(_, string) do
-    # [
-    #   content_tag(:div, eval_example(string), class: "example"),
-    #   content_tag(:div, string, class: "code")
-    # ]
-    # |> Enum.map(fn(x) -> safe_to_string(x) end)
-    # |> Enum.join("\n")
-
     string = String.trim(string)
     example = eval_example(string) |> safe_to_string()
 

--- a/lib/ex_styledoc/parser.ex
+++ b/lib/ex_styledoc/parser.ex
@@ -1,0 +1,38 @@
+defmodule ExStyledoc.Parser do
+  @moduledoc """
+  Functions to parse styledocs.
+  """
+
+  import Phoenix.HTML, only: [safe_to_string: 1]
+  # import Phoenix.HTML.Tag, only: [content_tag: 3]
+
+  @doc """
+  Parse a styledoc.
+  """
+  def parse_styledoc(doc) do
+    Regex.replace(~r/```(.*?)```/s, doc, &parse_example/2)
+    |> ExStyledoc.Markdown.to_html()
+  end
+
+  defp parse_example(_, string) do
+    # [
+    #   content_tag(:div, eval_example(string), class: "example"),
+    #   content_tag(:div, string, class: "code")
+    # ]
+    # |> Enum.map(fn(x) -> safe_to_string(x) end)
+    # |> Enum.join("\n")
+
+    string = String.trim(string)
+    example = eval_example(string) |> safe_to_string()
+
+    ~s"""
+    <div class="example">#{example}</div>
+    <div class="code"><pre><code class="elixir">#{string}</code></pre></div>
+    """
+  end
+
+  defp eval_example(string) do
+    {result, _} = Code.eval_string(string)
+    result
+  end
+end

--- a/lib/ex_styledoc/parser.ex
+++ b/lib/ex_styledoc/parser.ex
@@ -15,7 +15,12 @@ defmodule ExStyledoc.Parser do
 
   defp parse_example(_, string) do
     string = String.trim(string)
-    example = eval_example(string) |> safe_to_string()
+    example = eval_example(string)
+
+    example = case example do
+      {:safe, _data} -> safe_to_string(example)
+      _ -> example
+    end
 
     ~s"""
     <div class="example">#{example}</div>

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,9 @@ defmodule ExStyledoc.Mixfile do
   end
 
   defp deps do
-    []
+    [
+      {:earmark, "~> 1.1"}
+    ]
   end
 
   defp package do


### PR DESCRIPTION
This implements markdown support with code example extraction and parsing.
The parsing is a bit sloppy so might want to rethink how we want to do this.

## Styledoc

    @styledoc """
    Styledocs with examples:

    ### Regular code blocks

        IO.inspect "This is a regular code block"

    ```elixir
    IO.inspect "This is a regular code block"
    ```

    ### Example code blocks

    ```example
    # This is an example code block that will be rendered as a preview
    Phoenix.Cell.View.cell(Detroit.Web.ButtonCell, text: "Default")
    ```
    """

## Output

![screen shot 2017-07-25 at 12 59 34](https://user-images.githubusercontent.com/935529/28569193-2c405c30-7139-11e7-8c29-71b1d192f6a2.png)
